### PR TITLE
Fix README typos and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
 
 1. **Clone the repo:**
    ```bash
-   git clone https://github.com/your-username/chatswrap.git
-   cd chatswrap
+   git clone https://github.com/your-username/ChatsWrap.git
+   cd ChatsWrap
    ```
 
 2. **Install dependencies:**

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Chatswrap</title>
+  <title>ChatsWrap</title>
 </head>
 <body>
   <div id="root"></div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders signup form by default', () => {
+  render(<App />);
+  const signupButton = screen.getByRole('button', { name: /sign up/i });
+  expect(signupButton).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- correct capitalization in index.html title
- update README clone instructions to use ChatsWrap
- add a basic React test for the signup form

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fec364f908327837def961121d61d